### PR TITLE
Add basic htpasswd to frontend. Contribute to #10

### DIFF
--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "Generating .htpasswd file"
+perl -le 'print crypt($HTPASSWD, "f9")' | awk '{print "$HTUSER:"$1}' > ./.htpasswd
+
 echo "Building source image"
 docker build -t $DOCKER_SRC_IMAGE .
 

--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
-echo "Generating .htpasswd file"
-perl -le 'print crypt($HTPASSWD, "f9")' | awk '{print "$HTUSER:"$1}' > ./.htpasswd
+# If user and password are not provided, the frontend will be served without
+# authentication.
+if [ -n "$HTPASSWD" ] && [ -n "$HTUSER" ]; then
+  echo "Generating .htpasswd file"
+  perl -le 'print crypt($HTPASSWD, "f9")' | awk '{print "$HTUSER:"$1}' > ./.htpasswd
+fi  
 
 echo "Building source image"
 docker build -t $DOCKER_SRC_IMAGE .

--- a/.build_scripts/insert-env.js
+++ b/.build_scripts/insert-env.js
@@ -11,14 +11,6 @@ let fs = require('fs')
 let obj = YAML.load(input)
 
 var splitEnvs = [
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
-  'AWS_REGION',
-  'AWS_ECS_CLUSTER',
-  'DOCKER_SRC_IMAGE',
-  'DOCKER_REPOSITORY',
-  'DOCKER_USERNAME',
-  'DOCKER_PASSWORD'
 ]
 
 var envs = splitEnvs.map(function (e) {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,11 @@
 FROM nginx:stable-alpine
+
+# Copy the built site to the Nginx config
 COPY ./dist /usr/share/nginx/html
+
+# Remove the default Nginx config
+RUN rm -v /etc/nginx/conf.d/default.conf
+
+# Copy the config
+ADD nginx.conf /etc/nginx/conf.d/rra.conf
+ADD .htpasswd /etc/nginx/

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    auth_basic "Restricted Content";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
This script allows users to deploy the frontend with a user and password for basic authentication. This requires them to set the following env variables, either in `.travis.yml` or the UI:

- `$HTPASSWD`
- `$HTUSER`