### PR TITLE
Add zoom to project bounding box to iD iframe

### DIFF
--- a/app/assets/scripts/components/scenario/scenario-id-modal.js
+++ b/app/assets/scripts/components/scenario/scenario-id-modal.js
@@ -4,6 +4,7 @@ import ReactTooltip from 'react-tooltip';
 import c from 'classnames';
 
 import { t } from '../../utils/i18n';
+import boundsToMapLocation from '../../utils/zoom-to-bbox';
 import config from '../../config';
 import { showGlobalLoading, hideGlobalLoading } from '../global-loading';
 
@@ -15,7 +16,8 @@ const ScenarioIDModal = React.createClass({
     revealed: T.bool,
     onCloseClick: T.func,
 
-    scenarioData: T.object
+    scenarioData: T.object,
+    projectBbox: T.array
   },
 
   notifier: null,
@@ -73,6 +75,7 @@ const ScenarioIDModal = React.createClass({
   },
 
   render: function () {
+    const mapLocation = boundsToMapLocation(this.props.projectBbox);
     return (
       <Modal
         id='modal-scenario-metadata'
@@ -91,7 +94,7 @@ const ScenarioIDModal = React.createClass({
 
         <section className='ideditor-wrapper'>
           <h1 className='visually-hidden'>iD editor</h1>
-          <iframe src={config.iDEditor} className={c({'visually-hidden': !this.state.editorLoaded})} frameBorder='0' ref='editor'></iframe>
+          <iframe src={`${config.iDEditor}/#map=${mapLocation.zoom}/${mapLocation.center.lat}/${mapLocation.center.lng}`} className={c({'visually-hidden': !this.state.editorLoaded})} frameBorder='0' ref='editor'></iframe>
         </section>
 
         </ModalBody>

--- a/app/assets/scripts/utils/zoom-to-bbox.js
+++ b/app/assets/scripts/utils/zoom-to-bbox.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const boundsToMapLocation = (inputCoords) => {
+  const WORLD_DIM = { height: 256, width: 256 };
+  var ZOOM_MAX = 21;
+
+  // height is 32rem in RRA css
+  const mapHeight = 32 * Number(window.getComputedStyle(document.body)
+                         .getPropertyValue('font-size').replace(/px/, ''));
+  // width is container width minus lesser of 33.33% and 400px in iD css
+  const containerWidth = document.querySelector('#app-container').offsetWidth;
+  const mapSidebarWidth = containerWidth * 0.33 < 400 ? Math.round(containerWidth * 0.33) : 400;
+
+  const mapDimensions = {
+    width: containerWidth - mapSidebarWidth,
+    height: mapHeight
+  };
+
+  const bounds = {
+    southwest: {
+      lng: inputCoords[0],
+      lat: inputCoords[1]},
+    northeast: {
+      lng: inputCoords[2],
+      lat: inputCoords[3]}
+  };
+
+  const latRad = (lat) => {
+    const sin = Math.sin(lat * Math.PI / 180);
+    const radX2 = Math.log((1 + sin) / (1 - sin)) / 2;
+    return Math.max(Math.min(radX2, Math.PI), -Math.PI) / 2;
+  };
+
+  const getZoom = (mapPx, worldPx, fraction) => {
+    return Math.floor(Math.log(mapPx / worldPx / fraction) / Math.LN2);
+  };
+
+  const ne = bounds.northeast;
+  const sw = bounds.southwest;
+
+  const latFraction = (latRad(ne.lat) - latRad(sw.lat)) / Math.PI;
+
+  const lngDiff = ne.lng - sw.lng;
+  const lngFraction = ((lngDiff < 0) ? (lngDiff + 360) : lngDiff) / 360;
+
+  const latZoom = getZoom(mapDimensions.height, WORLD_DIM.height, latFraction);
+  const lngZoom = getZoom(mapDimensions.width, WORLD_DIM.width, lngFraction);
+
+  const zoom = Math.min(latZoom, lngZoom, ZOOM_MAX);
+
+  const center = {
+    lng: ((bounds.southwest.lng + bounds.northeast.lng) / 2).toFixed(4),
+    lat: ((bounds.southwest.lat + bounds.northeast.lat) / 2).toFixed(4)
+  };
+
+  return {zoom: zoom, center: center};
+};
+
+export default boundsToMapLocation;

--- a/app/assets/scripts/utils/zoom-to-bbox.js
+++ b/app/assets/scripts/utils/zoom-to-bbox.js
@@ -32,7 +32,7 @@ const boundsToMapLocation = (inputCoords) => {
   };
 
   const getZoom = (mapPx, worldPx, fraction) => {
-    return Math.floor(Math.log(mapPx / worldPx / fraction) / Math.LN2);
+    return Math.ceil((Math.log(mapPx / worldPx / fraction) / Math.LN2) / 0.25) * 0.25;
   };
 
   const ne = bounds.northeast;

--- a/app/assets/scripts/views/scenario-page.js
+++ b/app/assets/scripts/views/scenario-page.js
@@ -370,6 +370,7 @@ var ScenarioPage = React.createClass({
           revealed={this.state.scenarioIDModal}
           onCloseClick={this.closeModal.bind(null, 'edit-network')}
           scenarioData={dataScenario}
+          projectBbox={this.props.project.data.bbox}
         />
 
       </section>


### PR DESCRIPTION
Adds a util to convert project bounding boxes to zoom-level / center coordinate notation, and loads the iD editor iframe URL using the results. It accounts for distortions in the mercator projection at different latitudes and zoom levels, as well as the dimensions of the map element (it will need to be updated if the size of the map or its sidebar is changed). I tested it on several polygons with different sizes, locations, and orientations, and it seems to work well.

For quickly testing without needing to update the database, [this feature collection](https://gist.github.com/nbumbarger/8baeec1167ea5feb406739859b899466) can be loaded into iD, and `this.props.projectBbox` on [this line](https://github.com/WorldBank-Transport/rra-frontend/compare/feature/issues...nbumbarger:feature/zoom-to-bbox?expand=1#diff-0df6fae62eb3684d7397761464adec06R78)
can be overwritten with one of the following coordinate groups:
```
const projectBbox = [22.531585693359375, -25.120419105501256, 23.580780029296875, -24.617057340809513];
const projectBbox = [-72.0208740234375, 57.856443276115066, -71.6473388671875, 58.16490792851806];
const projectBbox = [-38.313, -11.89, -37.1525399, -10.5333431];
const projectBbox = [-75.849609375, 50.261253827584724, -63.2373046875, 56.58369172128337];
const projectBbox = [98.0859375, 57.98480801923985, 106.171875, 66.23145747862573];
const projectBbox = [125.859375, -26.431228064506424, 138.515625, -21.453068633086772];
```
cc @olafveerman @danielfdsilva 